### PR TITLE
added ci_min_scale attribute and added setting cropped output size in pixels

### DIFF
--- a/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaImageViewConfig.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaImageViewConfig.java
@@ -41,6 +41,9 @@ public class CropIwaImageViewConfig {
             config.setMaxScale(ta.getFloat(
                     R.styleable.CropIwaView_ci_max_scale,
                     config.getMaxScale()));
+            config.setMinScale(ta.getFloat(
+                    R.styleable.CropIwaView_ci_min_scale,
+                    config.getMinScale()));
             config.setImageTranslationEnabled(ta.getBoolean(
                     R.styleable.CropIwaView_ci_translation_enabled,
                     config.isImageTranslationEnabled()));

--- a/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaSaveConfig.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaSaveConfig.java
@@ -14,6 +14,7 @@ public class CropIwaSaveConfig {
     private Bitmap.CompressFormat compressFormat;
     private int quality;
     private int width, height;
+    private int widthPx, heightPx;
     private Uri dstUri;
 
     public CropIwaSaveConfig(Uri dstPath) {
@@ -21,6 +22,8 @@ public class CropIwaSaveConfig {
         this.compressFormat = Bitmap.CompressFormat.PNG;
         this.width = CropIwaBitmapManager.SIZE_UNSPECIFIED;
         this.height = CropIwaBitmapManager.SIZE_UNSPECIFIED;
+        this.widthPx = CropIwaBitmapManager.SIZE_UNSPECIFIED;
+        this.heightPx = CropIwaBitmapManager.SIZE_UNSPECIFIED;
         this.quality = 90;
     }
 
@@ -44,6 +47,14 @@ public class CropIwaSaveConfig {
         return dstUri;
     }
 
+    public int getWidthPx(){
+        return widthPx;
+    }
+
+    public int getHeightPx(){
+        return heightPx;
+    }
+
     public static class Builder {
 
         private CropIwaSaveConfig saveConfig;
@@ -65,6 +76,12 @@ public class CropIwaSaveConfig {
 
         public Builder setQuality(@IntRange(from = 0, to = 100) int quality) {
             saveConfig.quality = quality;
+            return this;
+        }
+
+        public Builder setSizeInPx(int width, int height){
+            saveConfig.widthPx = width;
+            saveConfig.heightPx = height;
             return this;
         }
 

--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
@@ -50,6 +50,12 @@ class CropImageTask extends AsyncTask<Void, Void, Throwable> {
 
             cropped = mask.applyMaskTo(cropped);
 
+            if(saveConfig.getHeightPx() != CropIwaBitmapManager.SIZE_UNSPECIFIED &&
+                    saveConfig.getWidthPx() != CropIwaBitmapManager.SIZE_UNSPECIFIED){
+                cropped = Bitmap.createScaledBitmap(
+                        cropped, saveConfig.getWidthPx(), saveConfig.getHeightPx(), false);
+            }
+
             Uri dst = saveConfig.getDstUri();
             OutputStream os = context.getContentResolver().openOutputStream(dst);
             cropped.compress(saveConfig.getCompressFormat(), saveConfig.getQuality(), os);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <attr name="ci_scale_enabled" format="boolean" />
         <attr name="ci_translation_enabled" format="boolean" />
         <attr name="ci_max_scale" format="float" />
+        <attr name="ci_min_scale" format="float" />
         <attr name="ci_initial_position" format="enum">
             <enum name="centerInside" value="0" />
             <enum name="centerCrop" value="1" />


### PR DESCRIPTION
I needed to set the min scale to zero but didn't want to do it programmatically do i added the ci_min_scale attribute. might be useful for others.
```xml
<com.steelkiwi.cropiwa.CropIwaView
        android:id="@+id/crop_view"
        android:layout_width="match_parent"
        android:layout_height="match_parent"
        app:ci_dynamic_aspect_ratio="false"
        app:ci_aspect_ratio_h="1"
        app:ci_aspect_ratio_w="1"
        app:ci_scale_enabled="true"
        app:ci_translation_enabled="true"
        app:ci_border_width="3dp"
        app:ci_max_scale="5"
        app:ci_min_scale="0" />
```

I needed a fixed dimension in px for the output cropped image. so I added .setSizeInPx(int width, int height)
```java
int px = 100;
mCropView.crop(new CropIwaSaveConfig.Builder(uri)
     .setCompressFormat(Bitmap.CompressFormat.JPEG)
     .setQuality(100)
     .setSizeInPx(px, px)
     .build());
```

[related to my earlier issue](https://github.com/steelkiwi/cropiwa/issues/5)