### PR TITLE
Remove allowBackup from Manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
If a project uses `allowBackup` in their Manifest, and uses this library, a merge error will occur