### PR TITLE
Catch IllegalArgumentException

### DIFF
--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropArea.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropArea.java
@@ -31,7 +31,7 @@ public class CropArea {
         this.cropRect = cropRect;
     }
 
-    public Bitmap applyCropTo(Bitmap bitmap) {
+    public Bitmap applyCropTo(Bitmap bitmap) throws IllegalArgumentException {
         Bitmap immutableCropped = Bitmap.createBitmap(bitmap,
                 findRealCoordinate(bitmap.getWidth(), cropRect.left, imageRect.width()),
                 findRealCoordinate(bitmap.getHeight(), cropRect.top, imageRect.height()),

--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
@@ -57,7 +57,7 @@ class CropImageTask extends AsyncTask<Void, Void, Throwable> {
 
             bitmap.recycle();
             cropped.recycle();
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             return e;
         }
         return null;


### PR DESCRIPTION
If you create a bitmap with invalid coords, IllegalArgumentException will be thrown.