### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -3,11 +3,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
Remove application attributes.

At the moment each consumer of the lib inherits the following attributes (unless they remove them in the manifest merger)
- `label`
- `supportsRtl`
- `autoBackup`

This PR removes them so consumers don't mistakenly keep them in their app