### PR TITLE
Catch all possible errors during cropping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     groupId = 'com.steelkiwi'
     uploadName = 'cropiwa'
     description = 'Configurable Custom Crop widget for Android'
-    publishVersion = '1.0.3'
+    publishVersion = '1.0.4'
     licences = ['Apache-2.0']
 }
 

--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
@@ -9,7 +9,6 @@ import com.steelkiwi.cropiwa.config.CropIwaSaveConfig;
 import com.steelkiwi.cropiwa.shape.CropIwaShapeMask;
 import com.steelkiwi.cropiwa.util.CropIwaUtils;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -57,8 +56,8 @@ class CropImageTask extends AsyncTask<Void, Void, Throwable> {
 
             bitmap.recycle();
             cropped.recycle();
-        } catch (IOException e) {
-            return e;
+        } catch (Throwable t) {
+            return t;
         }
         return null;
     }


### PR DESCRIPTION
When catching all throwables, issues #11 and #19 are resolved and can handled in the errorListener