### PR TITLE
Feature/memory usage optimisation

### DIFF
--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropImageTask.java
@@ -38,15 +38,12 @@ class CropImageTask extends AsyncTask<Void, Void, Throwable> {
     @Override
     protected Throwable doInBackground(Void... params) {
         try {
-            Bitmap bitmap = CropIwaBitmapManager.get().loadToMemory(
-                    context, srcUri, saveConfig.getWidth(),
-                    saveConfig.getHeight());
 
-            if (bitmap == null) {
+            Bitmap cropped = cropArea.applyCropTo(context, srcUri, saveConfig.getWidth(), saveConfig.getHeight());
+
+            if (cropped == null) {
                 return new NullPointerException("Failed to load bitmap");
             }
-
-            Bitmap cropped = cropArea.applyCropTo(bitmap);
 
             cropped = mask.applyMaskTo(cropped);
 
@@ -55,7 +52,6 @@ class CropImageTask extends AsyncTask<Void, Void, Throwable> {
             cropped.compress(saveConfig.getCompressFormat(), saveConfig.getQuality(), os);
             CropIwaUtils.closeSilently(os);
 
-            bitmap.recycle();
             cropped.recycle();
         } catch (IOException e) {
             return e;


### PR DESCRIPTION
Memory optimisation fix.
In current implementation to get cropped image bitmap is uploaded to memory three times:
1st time - original imgae in  tryLoadBitmap() method - by BitmapFactory.decodeStream(is, null, options);
2nd and 3rd - when we crop bitmap in applyCrop() method and whne we copy bytes from immutable cropped bitmap.

Usage of BitmapRegionDecoder allows us to load image to memory only once and in cropped size.
I've tested one image with constant crop area. Current implemetation allocates ~ 112MB. BitmapRegionDecoder implementation allocates 38mb.
Cropping time is slightly shorter.

![memory_crop](https://user-images.githubusercontent.com/2233176/32050028-09f0fa1e-ba58-11e7-91d3-ddb36de70dd7.png)
On top of image current allocations. On the bottom of image's new version allocation.

